### PR TITLE
Skip Intro button enhancements: Show/hide with OSD during intro & fade out styling

### DIFF
--- a/src/assets/css/videoosd.scss
+++ b/src/assets/css/videoosd.scss
@@ -394,9 +394,9 @@
     display: inline-block;
     cursor: pointer;
     box-shadow: inset 0 0 0 0 #f9f9f9;
-    -webkit-transition: ease-out 0.4s;
-    -moz-transition: ease-out 0.4s;
-    transition: ease-out 0.4s;
+    -webkit-transition: ease-out 0.4s box-shadow;
+    -moz-transition: ease-out 0.4s box-shadow;
+    transition: ease-out 0.4s box-shadow;
 }
 
 @media (max-width: 1080px) {
@@ -407,7 +407,15 @@
 
 .skipIntro:hover {
     box-shadow: inset 400px 0 0 0 #f9f9f9;
-    -webkit-transition: ease-in 1s;
-    -moz-transition: ease-in 1s;
-    transition: ease-in 1s;
+    -webkit-transition: ease-in 1s box-shadow;
+    -moz-transition: ease-in 1s box-shadow;
+    transition: ease-in 1s box-shadow;
+}
+
+.skipIntro.hidden {
+    opacity: 0;
+    pointer-events: none;
+    -webkit-transition: ease-in-out 0.1s opacity;
+    -moz-transition: ease-in-out 0.1s opacity;
+    transition: ease-in-out 0.1s opacity;
 }

--- a/src/controllers/playback/video/index.html
+++ b/src/controllers/playback/video/index.html
@@ -6,7 +6,7 @@
         </div>
     </div>
     <div class="upNextContainer hide"></div>
-    <div class="skipIntro hide">
+    <div class="skipIntro hidden">
         <button is="paper-icon-button-light" class="btnSkipIntro paper-icon-button-light">
             Skip Intro
             <span class="material-icons skip_next"></span>

--- a/src/controllers/playback/video/index.html
+++ b/src/controllers/playback/video/index.html
@@ -1,19 +1,8 @@
-<div
-    id="videoOsdPage"
-    data-role="page"
-    class="page libraryPage"
-    data-backbutton="true"
->
+<div id="videoOsdPage" data-role="page" class="page libraryPage" data-backbutton="true">
     <div class="syncPlayContainer">
         <div id="syncPlayIcon" class="syncPlayIconCircle">
-            <span
-                class="primary-icon material-icons play"
-                aria-hidden="true"
-            ></span>
-            <span
-                class="secondary-icon material-icons play"
-                aria-hidden="true"
-            ></span>
+            <span class="primary-icon material-icons play" aria-hidden="true"></span>
+            <span class="secondary-icon material-icons play" aria-hidden="true"></span>
         </div>
     </div>
     <div class="upNextContainer hide"></div>
@@ -22,10 +11,7 @@
             <div class="osdTextContainer osdMainTextContainer">
                 <h3 class="osdTitle"></h3>
                 <div class="osdMediaStatus hide">
-                    <span
-                        class="material-icons animate autorenew"
-                        aria-hidden="true"
-                    ></span>
+                    <span class="material-icons animate autorenew" aria-hidden="true"></span>
                     <span>${FetchingData}</span>
                 </div>
             </div>
@@ -33,214 +19,81 @@
             <div class="osdTextContainer osdSecondaryMediaInfo"></div>
 
             <div class="flex flex-direction-row align-items-center">
-                <div
-                    class="osdTextContainer startTimeText osdPositionText"
-                    style="margin: 0 0.25em 0 0"
-                ></div>
-                <div
-                    class="sliderContainer flex-grow"
-                    style="margin: 0.5em 0 0.25em"
-                >
-                    <input
-                        type="range"
-                        step=".01"
-                        min="0"
-                        max="100"
-                        value="0"
-                        is="emby-slider"
-                        class="osdPositionSlider"
-                        data-slider-keep-progress="true"
-                    />
+                <div class="osdTextContainer startTimeText osdPositionText" style="margin: 0 .25em 0 0;"></div>
+                <div class="sliderContainer flex-grow" style="margin: .5em 0 .25em;">
+                    <input type="range" step=".01" min="0" max="100" value="0" is="emby-slider" class="osdPositionSlider" data-slider-keep-progress="true" />
                 </div>
-                <div
-                    class="osdTextContainer endTimeText osdDurationText"
-                    style="margin: 0 0 0 0.25em"
-                ></div>
+                <div class="osdTextContainer endTimeText osdDurationText" style="margin: 0 0 0 .25em;"></div>
             </div>
 
             <div class="buttons focuscontainer-x">
-                <button
-                    is="paper-icon-button-light"
-                    class="btnRecord autoSize hide"
-                >
-                    <span
-                        class="xlargePaperIconButton material-icons fiber_manual_record"
-                        aria-hidden="true"
-                    ></span>
+                <button is="paper-icon-button-light" class="btnRecord autoSize hide">
+                    <span class="xlargePaperIconButton material-icons fiber_manual_record" aria-hidden="true"></span>
                 </button>
 
-                <button
-                    is="paper-icon-button-light"
-                    class="btnPreviousTrack autoSize hide"
-                    title="${PreviousTrack}"
-                >
-                    <span
-                        class="xlargePaperIconButton material-icons skip_previous"
-                        aria-hidden="true"
-                    ></span>
+                <button is="paper-icon-button-light" class="btnPreviousTrack autoSize hide" title="${PreviousTrack}">
+                    <span class="xlargePaperIconButton material-icons skip_previous" aria-hidden="true"></span>
                 </button>
 
-                <button
-                    is="paper-icon-button-light"
-                    class="btnPreviousChapter autoSize hide"
-                    title="${PreviousChapter}"
-                >
-                    <span
-                        class="xlargePaperIconButton material-icons undo"
-                        aria-hidden="true"
-                    ></span>
+                <button is="paper-icon-button-light" class="btnPreviousChapter autoSize hide" title="${PreviousChapter}">
+                    <span class="xlargePaperIconButton material-icons undo" aria-hidden="true"></span>
                 </button>
 
-                <button
-                    is="paper-icon-button-light"
-                    class="btnRewind"
-                    title="${Rewind} (j)"
-                    aria-label="${Rewind}"
-                >
-                    <span
-                        class="xlargePaperIconButton material-icons fast_rewind"
-                        aria-hidden="true"
-                    ></span>
+                <button is="paper-icon-button-light" class="btnRewind" title="${Rewind} (j)" aria-label="${Rewind}">
+                    <span class="xlargePaperIconButton material-icons fast_rewind" aria-hidden="true"></span>
                 </button>
 
                 <button is="paper-icon-button-light" class="btnPause autoSize">
-                    <span
-                        class="xlargePaperIconButton material-icons pause"
-                        aria-hidden="true"
-                    ></span>
+                    <span class="xlargePaperIconButton material-icons pause" aria-hidden="true"></span>
                 </button>
 
-                <button
-                    is="paper-icon-button-light"
-                    class="btnFastForward"
-                    title="${FastForward} (l)"
-                    aria-label="${FastForward}"
-                >
-                    <span
-                        class="xlargePaperIconButton material-icons fast_forward"
-                        aria-hidden="true"
-                    ></span>
+                <button is="paper-icon-button-light" class="btnFastForward" title="${FastForward} (l)" aria-label="${FastForward}">
+                    <span class="xlargePaperIconButton material-icons fast_forward" aria-hidden="true"></span>
                 </button>
 
-                <button
-                    is="paper-icon-button-light"
-                    class="btnNextChapter autoSize hide"
-                    title="${NextChapter}"
-                >
-                    <span
-                        class="xlargePaperIconButton material-icons redo"
-                        aria-hidden="true"
-                    ></span>
+                <button is="paper-icon-button-light" class="btnNextChapter autoSize hide" title="${NextChapter}">
+                    <span class="xlargePaperIconButton material-icons redo" aria-hidden="true"></span>
                 </button>
 
-                <button
-                    is="paper-icon-button-light"
-                    class="btnNextTrack autoSize hide"
-                    title="${NextTrack}"
-                >
-                    <span
-                        class="xlargePaperIconButton material-icons skip_next"
-                        aria-hidden="true"
-                    ></span>
+                <button is="paper-icon-button-light" class="btnNextTrack autoSize hide" title="${NextTrack}">
+                    <span class="xlargePaperIconButton material-icons skip_next" aria-hidden="true"></span>
                 </button>
 
                 <div class="osdTimeText">
                     <span class="endsAtText"></span>
                 </div>
 
-                <button
-                    is="paper-icon-button-light"
-                    class="btnSubtitles hide autoSize"
-                    title="${Subtitles}"
-                >
-                    <span
-                        class="xlargePaperIconButton material-icons closed_caption"
-                        aria-hidden="true"
-                    ></span>
+                <button is="paper-icon-button-light" class="btnSubtitles hide autoSize" title="${Subtitles}">
+                    <span class="xlargePaperIconButton material-icons closed_caption" aria-hidden="true"></span>
                 </button>
-                <button
-                    is="paper-icon-button-light"
-                    class="btnAudio hide autoSize"
-                    title="${Audio}"
-                >
-                    <span
-                        class="xlargePaperIconButton material-icons audiotrack"
-                        aria-hidden="true"
-                    ></span>
+                <button is="paper-icon-button-light" class="btnAudio hide autoSize" title="${Audio}">
+                    <span class="xlargePaperIconButton material-icons audiotrack" aria-hidden="true"></span>
                 </button>
                 <div class="volumeButtons hide-mouse-idle-tv">
-                    <button
-                        is="paper-icon-button-light"
-                        class="buttonMute autoSize"
-                        title="${Mute} (m)"
-                        aria-label="${Mute}"
-                    >
-                        <span
-                            class="xlargePaperIconButton material-icons volume_up"
-                            aria-hidden="true"
-                        ></span>
+                    <button is="paper-icon-button-light" class="buttonMute autoSize" title="${Mute} (m)" aria-label="${Mute}">
+                        <span class="xlargePaperIconButton material-icons volume_up" aria-hidden="true"></span>
                     </button>
                     <div class="sliderContainer osdVolumeSliderContainer">
-                        <input
-                            is="emby-slider"
-                            type="range"
-                            step="1"
-                            min="0"
-                            max="100"
-                            value="0"
-                            class="osdVolumeSlider"
-                        />
+                        <input is="emby-slider" type="range" step="1" min="0" max="100" value="0" class="osdVolumeSlider" />
                     </div>
                 </div>
-                <button
-                    is="paper-icon-button-light"
-                    class="btnVideoOsdSettings autoSize"
-                    title="${Settings}"
-                >
-                    <span
-                        class="largePaperIconButton material-icons settings"
-                        aria-hidden="true"
-                    ></span>
+                <button is="paper-icon-button-light" class="btnVideoOsdSettings autoSize" title="${Settings}">
+                    <span class="largePaperIconButton material-icons settings" aria-hidden="true"></span>
                 </button>
-                <button
-                    is="paper-icon-button-light"
-                    class="btnAirPlay hide autoSize"
-                    title="${AirPlay}"
-                >
-                    <span
-                        class="xlargePaperIconButton material-icons airplay"
-                        aria-hidden="true"
-                    ></span>
+                <button is="paper-icon-button-light" class="btnAirPlay hide autoSize" title="${AirPlay}">
+                    <span class="xlargePaperIconButton material-icons airplay" aria-hidden="true"></span>
                 </button>
-                <button
-                    is="paper-icon-button-light"
-                    class="btnPip hide autoSize"
-                    title="${PictureInPicture}"
-                >
-                    <span
-                        class="xlargePaperIconButton material-icons picture_in_picture_alt"
-                        aria-hidden="true"
-                    ></span>
+                <button is="paper-icon-button-light" class="btnPip hide autoSize" title="${PictureInPicture}">
+                    <span class="xlargePaperIconButton material-icons picture_in_picture_alt" aria-hidden="true"></span>
                 </button>
-                <button
-                    is="paper-icon-button-light"
-                    class="btnFullscreen hide autoSize"
-                    title="${Fullscreen} (f)"
-                    aria-label="${Fullscreen}"
-                >
-                    <span
-                        class="xlargePaperIconButton material-icons fullscreen"
-                        aria-hidden="true"
-                    ></span>
+                <button is="paper-icon-button-light" class="btnFullscreen hide autoSize" title="${Fullscreen} (f)" aria-label="${Fullscreen}">
+                    <span class="xlargePaperIconButton material-icons fullscreen" aria-hidden="true"></span>
                 </button>
             </div>
         </div>
     </div>
     <div class="skipIntro hidden">
-        <button
-            is="paper-icon-button-light"
-            class="btnSkipIntro paper-icon-button-light"
-        >
+        <button is="paper-icon-button-light" class="btnSkipIntro paper-icon-button-light">
             Skip Intro
             <span class="material-icons skip_next"></span>
         </button>

--- a/src/controllers/playback/video/index.html
+++ b/src/controllers/playback/video/index.html
@@ -1,23 +1,31 @@
-<div id="videoOsdPage" data-role="page" class="page libraryPage" data-backbutton="true">
+<div
+    id="videoOsdPage"
+    data-role="page"
+    class="page libraryPage"
+    data-backbutton="true"
+>
     <div class="syncPlayContainer">
         <div id="syncPlayIcon" class="syncPlayIconCircle">
-            <span class="primary-icon material-icons play" aria-hidden="true"></span>
-            <span class="secondary-icon material-icons play" aria-hidden="true"></span>
+            <span
+                class="primary-icon material-icons play"
+                aria-hidden="true"
+            ></span>
+            <span
+                class="secondary-icon material-icons play"
+                aria-hidden="true"
+            ></span>
         </div>
     </div>
     <div class="upNextContainer hide"></div>
-    <div class="skipIntro hidden">
-        <button is="paper-icon-button-light" class="btnSkipIntro paper-icon-button-light">
-            Skip Intro
-            <span class="material-icons skip_next"></span>
-        </button>
-    </div>
     <div class="videoOsdBottom videoOsdBottom-maincontrols">
         <div class="osdControls">
             <div class="osdTextContainer osdMainTextContainer">
                 <h3 class="osdTitle"></h3>
                 <div class="osdMediaStatus hide">
-                    <span class="material-icons animate autorenew" aria-hidden="true"></span>
+                    <span
+                        class="material-icons animate autorenew"
+                        aria-hidden="true"
+                    ></span>
                     <span>${FetchingData}</span>
                 </div>
             </div>
@@ -25,77 +33,216 @@
             <div class="osdTextContainer osdSecondaryMediaInfo"></div>
 
             <div class="flex flex-direction-row align-items-center">
-                <div class="osdTextContainer startTimeText osdPositionText" style="margin: 0 .25em 0 0;"></div>
-                <div class="sliderContainer flex-grow" style="margin: .5em 0 .25em;">
-                    <input type="range" step=".01" min="0" max="100" value="0" is="emby-slider" class="osdPositionSlider" data-slider-keep-progress="true" />
+                <div
+                    class="osdTextContainer startTimeText osdPositionText"
+                    style="margin: 0 0.25em 0 0"
+                ></div>
+                <div
+                    class="sliderContainer flex-grow"
+                    style="margin: 0.5em 0 0.25em"
+                >
+                    <input
+                        type="range"
+                        step=".01"
+                        min="0"
+                        max="100"
+                        value="0"
+                        is="emby-slider"
+                        class="osdPositionSlider"
+                        data-slider-keep-progress="true"
+                    />
                 </div>
-                <div class="osdTextContainer endTimeText osdDurationText" style="margin: 0 0 0 .25em;"></div>
+                <div
+                    class="osdTextContainer endTimeText osdDurationText"
+                    style="margin: 0 0 0 0.25em"
+                ></div>
             </div>
 
             <div class="buttons focuscontainer-x">
-                <button is="paper-icon-button-light" class="btnRecord autoSize hide">
-                    <span class="xlargePaperIconButton material-icons fiber_manual_record" aria-hidden="true"></span>
+                <button
+                    is="paper-icon-button-light"
+                    class="btnRecord autoSize hide"
+                >
+                    <span
+                        class="xlargePaperIconButton material-icons fiber_manual_record"
+                        aria-hidden="true"
+                    ></span>
                 </button>
 
-                <button is="paper-icon-button-light" class="btnPreviousTrack autoSize hide" title="${PreviousTrack}">
-                    <span class="xlargePaperIconButton material-icons skip_previous" aria-hidden="true"></span>
+                <button
+                    is="paper-icon-button-light"
+                    class="btnPreviousTrack autoSize hide"
+                    title="${PreviousTrack}"
+                >
+                    <span
+                        class="xlargePaperIconButton material-icons skip_previous"
+                        aria-hidden="true"
+                    ></span>
                 </button>
 
-                <button is="paper-icon-button-light" class="btnPreviousChapter autoSize hide" title="${PreviousChapter}">
-                    <span class="xlargePaperIconButton material-icons undo" aria-hidden="true"></span>
+                <button
+                    is="paper-icon-button-light"
+                    class="btnPreviousChapter autoSize hide"
+                    title="${PreviousChapter}"
+                >
+                    <span
+                        class="xlargePaperIconButton material-icons undo"
+                        aria-hidden="true"
+                    ></span>
                 </button>
 
-                <button is="paper-icon-button-light" class="btnRewind" title="${Rewind} (j)" aria-label="${Rewind}">
-                    <span class="xlargePaperIconButton material-icons fast_rewind" aria-hidden="true"></span>
+                <button
+                    is="paper-icon-button-light"
+                    class="btnRewind"
+                    title="${Rewind} (j)"
+                    aria-label="${Rewind}"
+                >
+                    <span
+                        class="xlargePaperIconButton material-icons fast_rewind"
+                        aria-hidden="true"
+                    ></span>
                 </button>
 
                 <button is="paper-icon-button-light" class="btnPause autoSize">
-                    <span class="xlargePaperIconButton material-icons pause" aria-hidden="true"></span>
+                    <span
+                        class="xlargePaperIconButton material-icons pause"
+                        aria-hidden="true"
+                    ></span>
                 </button>
 
-                <button is="paper-icon-button-light" class="btnFastForward" title="${FastForward} (l)" aria-label="${FastForward}">
-                    <span class="xlargePaperIconButton material-icons fast_forward" aria-hidden="true"></span>
+                <button
+                    is="paper-icon-button-light"
+                    class="btnFastForward"
+                    title="${FastForward} (l)"
+                    aria-label="${FastForward}"
+                >
+                    <span
+                        class="xlargePaperIconButton material-icons fast_forward"
+                        aria-hidden="true"
+                    ></span>
                 </button>
 
-                <button is="paper-icon-button-light" class="btnNextChapter autoSize hide" title="${NextChapter}">
-                    <span class="xlargePaperIconButton material-icons redo" aria-hidden="true"></span>
+                <button
+                    is="paper-icon-button-light"
+                    class="btnNextChapter autoSize hide"
+                    title="${NextChapter}"
+                >
+                    <span
+                        class="xlargePaperIconButton material-icons redo"
+                        aria-hidden="true"
+                    ></span>
                 </button>
 
-                <button is="paper-icon-button-light" class="btnNextTrack autoSize hide" title="${NextTrack}">
-                    <span class="xlargePaperIconButton material-icons skip_next" aria-hidden="true"></span>
+                <button
+                    is="paper-icon-button-light"
+                    class="btnNextTrack autoSize hide"
+                    title="${NextTrack}"
+                >
+                    <span
+                        class="xlargePaperIconButton material-icons skip_next"
+                        aria-hidden="true"
+                    ></span>
                 </button>
 
                 <div class="osdTimeText">
                     <span class="endsAtText"></span>
                 </div>
 
-                <button is="paper-icon-button-light" class="btnSubtitles hide autoSize" title="${Subtitles}">
-                    <span class="xlargePaperIconButton material-icons closed_caption" aria-hidden="true"></span>
+                <button
+                    is="paper-icon-button-light"
+                    class="btnSubtitles hide autoSize"
+                    title="${Subtitles}"
+                >
+                    <span
+                        class="xlargePaperIconButton material-icons closed_caption"
+                        aria-hidden="true"
+                    ></span>
                 </button>
-                <button is="paper-icon-button-light" class="btnAudio hide autoSize" title="${Audio}">
-                    <span class="xlargePaperIconButton material-icons audiotrack" aria-hidden="true"></span>
+                <button
+                    is="paper-icon-button-light"
+                    class="btnAudio hide autoSize"
+                    title="${Audio}"
+                >
+                    <span
+                        class="xlargePaperIconButton material-icons audiotrack"
+                        aria-hidden="true"
+                    ></span>
                 </button>
                 <div class="volumeButtons hide-mouse-idle-tv">
-                    <button is="paper-icon-button-light" class="buttonMute autoSize" title="${Mute} (m)" aria-label="${Mute}">
-                        <span class="xlargePaperIconButton material-icons volume_up" aria-hidden="true"></span>
+                    <button
+                        is="paper-icon-button-light"
+                        class="buttonMute autoSize"
+                        title="${Mute} (m)"
+                        aria-label="${Mute}"
+                    >
+                        <span
+                            class="xlargePaperIconButton material-icons volume_up"
+                            aria-hidden="true"
+                        ></span>
                     </button>
                     <div class="sliderContainer osdVolumeSliderContainer">
-                        <input is="emby-slider" type="range" step="1" min="0" max="100" value="0" class="osdVolumeSlider" />
+                        <input
+                            is="emby-slider"
+                            type="range"
+                            step="1"
+                            min="0"
+                            max="100"
+                            value="0"
+                            class="osdVolumeSlider"
+                        />
                     </div>
                 </div>
-                <button is="paper-icon-button-light" class="btnVideoOsdSettings autoSize" title="${Settings}">
-                    <span class="largePaperIconButton material-icons settings" aria-hidden="true"></span>
+                <button
+                    is="paper-icon-button-light"
+                    class="btnVideoOsdSettings autoSize"
+                    title="${Settings}"
+                >
+                    <span
+                        class="largePaperIconButton material-icons settings"
+                        aria-hidden="true"
+                    ></span>
                 </button>
-                <button is="paper-icon-button-light" class="btnAirPlay hide autoSize" title="${AirPlay}">
-                    <span class="xlargePaperIconButton material-icons airplay" aria-hidden="true"></span>
+                <button
+                    is="paper-icon-button-light"
+                    class="btnAirPlay hide autoSize"
+                    title="${AirPlay}"
+                >
+                    <span
+                        class="xlargePaperIconButton material-icons airplay"
+                        aria-hidden="true"
+                    ></span>
                 </button>
-                <button is="paper-icon-button-light" class="btnPip hide autoSize" title="${PictureInPicture}">
-                    <span class="xlargePaperIconButton material-icons picture_in_picture_alt" aria-hidden="true"></span>
+                <button
+                    is="paper-icon-button-light"
+                    class="btnPip hide autoSize"
+                    title="${PictureInPicture}"
+                >
+                    <span
+                        class="xlargePaperIconButton material-icons picture_in_picture_alt"
+                        aria-hidden="true"
+                    ></span>
                 </button>
-                <button is="paper-icon-button-light" class="btnFullscreen hide autoSize" title="${Fullscreen} (f)" aria-label="${Fullscreen}">
-                    <span class="xlargePaperIconButton material-icons fullscreen" aria-hidden="true"></span>
+                <button
+                    is="paper-icon-button-light"
+                    class="btnFullscreen hide autoSize"
+                    title="${Fullscreen} (f)"
+                    aria-label="${Fullscreen}"
+                >
+                    <span
+                        class="xlargePaperIconButton material-icons fullscreen"
+                        aria-hidden="true"
+                    ></span>
                 </button>
             </div>
         </div>
+    </div>
+    <div class="skipIntro hidden">
+        <button
+            is="paper-icon-button-light"
+            class="btnSkipIntro paper-icon-button-light"
+        >
+            Skip Intro
+            <span class="material-icons skip_next"></span>
+        </button>
     </div>
 </div>

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -233,9 +233,9 @@ import { appRouter } from '../../../components/appRouter';
                 if (
                     seconds >= tvIntro.ShowSkipPromptAt
                     && seconds <= tvIntro.IntroEnd
-                    && skipIntro.classList.contains("hide")
+                    && skipIntro.classList.contains("hidden")
                 ) {
-                    skipIntro.classList.remove("hide");
+                    skipIntro.classList.remove("hidden");
                 }
             }
         }
@@ -254,9 +254,9 @@ import { appRouter } from '../../../components/appRouter';
                 // Hide the skip intro button when OSD closes, only outside of the window where it should always be shown
                 if (
                     (seconds >= tvIntro.HideSkipPromptAt || seconds < tvIntro.ShowSkipPromptAt)
-                    && !skipIntro.classList.contains("hide")
+                    && !skipIntro.classList.contains("hidden")
                 ) {
-                    skipIntro.classList.add("hide");
+                    skipIntro.classList.add("hidden");
                 }
             }
         }
@@ -644,7 +644,7 @@ import { appRouter } from '../../../components/appRouter';
 
                         if (seconds < tvIntro.ShowSkipPromptAt || seconds > tvIntro.IntroEnd) {
                             // Always hide the button when we are outside of the intro range completely
-                            if (!skipIntro.classList.contains("hide")) skipIntro.classList.add("hide");
+                            if (!skipIntro.classList.contains("hidden")) skipIntro.classList.add("hidden");
                         } else if (
                             (
                                 seconds >= tvIntro.ShowSkipPromptAt
@@ -653,10 +653,10 @@ import { appRouter } from '../../../components/appRouter';
                             || osdShown
                         ) {
                             // Otherwise, when we are between the show/hide range, always show, or do nothing
-                            if (skipIntro.classList.contains("hide")) skipIntro.classList.remove("hide");
+                            if (skipIntro.classList.contains("hidden")) skipIntro.classList.remove("hidden");
                         } else if (!osdShown) {
                             // If we are here, then the on screen display is hidden
-                            if (!skipIntro.classList.contains("hide")) skipIntro.classList.add("hide");
+                            if (!skipIntro.classList.contains("hidden")) skipIntro.classList.add("hidden");
                         }
                     }
                 }


### PR DESCRIPTION
Hey there 👋, this PR refactors the client-side logic for the Skip Intro button so that it will be shown with the video player's on-screen display (OSD) elements, but only during the time range for the intro given by your API. I also refactored the styling slightly so that the button fades out when hidden.

Here is a quick video demonstrating the enhancement: https://streamable.com/0cqajv. My window is 15 seconds, please skip ahead to see how after that window, the button only shows with the OSD, and only during the intro.

Thanks for your work on this. I love this plugin and this was the only thing I thought could use some enhancement after missing the button time window a few times, and hitting a few 5-second intros with 10 seconds of extra button time.

**Changes**
- Moved button logic within `onTimeUpdate` handler to its own if block to account for future changes to this function
- Reorganized logic so that:
  - If we are before `ShowSkipPromptAt` or after `IntroEnd`, always hide the button as we are definitely out of the intro range
  - When we are between `ShowSkipPromptAt` and `HideSkipPromptAt`, always show the button
  - Otherwise hide it if the OSD is not shown
- Added logic to show and hide the button appropriately within `showOsd` and `hideOsd`
- Use `hidden` class instead of `hide` class on the button element
- Style the button's `hidden` class with `opacity: 0` instead of `display: none` to get a fade out effect
- Move button element below OSD bottom element so it renders above it in the browser

